### PR TITLE
FI-21-PASS-command-Check-Sending-function-Part2

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,17 +3,17 @@
 #                                                         :::      ::::::::    #
 #    Makefile                                           :+:      :+:    :+:    #
 #                                                     +:+ +:+         +:+      #
-#    By: jhusso <jhusso@student.42.fr>              +#+  +:+       +#+         #
+#    By: yoonslee <yoonslee@student.42.fr>          +#+  +:+       +#+         #
 #                                                 +#+#+#+#+#+   +#+            #
 #    Created: 2024/02/05 16:26:39 by jpelaez-          #+#    #+#              #
-#    Updated: 2024/02/13 14:53:36 by jhusso           ###   ########.fr        #
+#    Updated: 2024/02/14 09:08:43 by yoonslee         ###   ########.fr        #
 #                                                                              #
 # **************************************************************************** #
 
 NAME = ircserv
 
-SRC = main.cpp SetServer.cpp Client.cpp SetServer_utils.cpp Message.cpp \
-commands/Nick.cpp commands/Pass.cpp
+SRC = main.cpp SetServer.cpp Client.cpp SetServer_utils.cpp Message.cpp commands/pass.cpp\
+# commands/Nick.cpp 
 
 DIR_SRCS = srcs/
 DIR_OBJS = objs/
@@ -31,7 +31,7 @@ $(NAME): $(OBJS)
 		$(CC) $^ -o $@
 
 ${OBJS} : ${DIR_OBJS}%.o : ${DIR_SRCS}%.cpp
-	mkdir -p ${DIR_OBJS}
+	mkdir -p ${DIR_OBJS}/commands
 	${CC} ${FLAGS} ${INCLUDES} $< -o $@
 
 clean:

--- a/includes/Client.hpp
+++ b/includes/Client.hpp
@@ -10,6 +10,7 @@
 class Client{
 	private:
 		int				_client_fd;
+		std::string		_serverName;
 		std::string		_readbuf;
 		std::string		_sendbuf;
 		std::string		_nickname;
@@ -36,6 +37,8 @@ class Client{
 		void	setMode(std::string mode);
 		void	setIPaddress(char *ip);
 		void	setRegisteration(int reg);
+		const int	&getClientFd(void);
+		const std::string	&getServerName(void);
 		const std::string	&getNickName(void);
 		const std::string	&getUserName(void);
 		const std::string	&getRealName(void);

--- a/includes/Commands.hpp
+++ b/includes/Commands.hpp
@@ -2,11 +2,14 @@
 # define COMMANDS_HPP
 
 # include "Common.hpp"
+# include "Message.hpp"
+# include "Client.hpp"
 
+class Client;
 class Message; 
 
 int cmd_nick(Message &msg, int client_fd);
-int cmd_pass(Message &msg, int client_fd);
+int cmd_pass(Message &msg, Client &Client);
 int cmd_quit(Message &msg, int client_fd);
 int cmd_user(Message &msg, int client_fd);
 int cmd_whois(Message &msg, int client_fd);

--- a/includes/Reply.hpp
+++ b/includes/Reply.hpp
@@ -3,7 +3,7 @@
 # define REPLY_HPP
 
 //ERROR REPLIES
-# define ERR_NEEDMOREPARAMS(servename)(":" + servername + " 461 * :Not enough parameters" + "\r\n")	
+# define ERR_NEEDMOREPARAMS(serverName)(":" + servername + " 461 * :Not enough parameters" + "\r\n")	
 # define ERR_ALREADYREGISTRED(servername)(":" + servername + " 462 * :You may not reregister" + "\r\n")
 # define ERR_PASSWDMISMATCH(servername)(":" + servername + " 464 * :Password incorrect" + "\r\n")
 

--- a/includes/Server.hpp
+++ b/includes/Server.hpp
@@ -32,6 +32,7 @@ class Server
 	private:
 		Server();
 		std::string port;
+		std::string serverName;
 		std::string password;
 		std::vector<struct pollfd> pfds;
 		int pollfd_count;
@@ -52,6 +53,7 @@ class Server
 		void setMessage(const char* msg);
 		int parseMessage(int client_fd);
 		int get_command_type(std::string command);
+		const std::string &getServerName() const;
 };
 
 #endif

--- a/srcs/Client.cpp
+++ b/srcs/Client.cpp
@@ -8,7 +8,7 @@ Client::Client(){};
  * @param new_fd socket fd
  * @param _mode mode for USER, CHANNEL
  */
-Client::Client(int new_fd): _client_fd(new_fd), _mode("+Ziw"), _isRegistered(0) {}
+Client::Client(int new_fd): _client_fd(new_fd), _serverName("IRCserv"), _mode("+Ziw"), _isRegistered(0) {}
 
 Client::~Client(){}
 
@@ -70,6 +70,8 @@ void	Client::setRegisteration(int reg)
 	_isRegistered = reg;
 }
 
+const int	&Client::getClientFd(void){return(_client_fd);}
+const std::string	&Client::getServerName(void){return(_serverName);}
 const std::string	&Client::getNickName(void){return(_nickname);}
 const std::string	&Client::getUserName(void){return(_username);}
 const std::string	&Client::getRealName(void){return(_realname);}

--- a/srcs/Message.cpp
+++ b/srcs/Message.cpp
@@ -11,17 +11,17 @@ Message::Message(std::string input)
 		if (index == 0)
 		{
 			this->command = token;
-			// std::cout << "COMMAND: " << this->command << std::endl;
+			std::cout << "COMMAND: " << this->command << std::endl;
 		}
-		else if (index > 1  && token[0] != ':')
+		else if (index >= 1  && token[0] != ':')
 		{
 			this->params.push_back(token);
-			// std::cout << "PARAM: " << token << std::endl;
+			std::cout << "PARAM: " << token << std::endl;
 		}
-		else if (index > 1 && token[0] == ':')
+		else if (index >= 1 && token[0] == ':')
 		{
 			std::getline(iss, trailing);
-			// std::cout << "TRAIILING: " << trailing << std::endl;
+			std::cout << "TRAIILING: " << trailing << std::endl;
 		}
 		index ++;
 	}

--- a/srcs/SetServer.cpp
+++ b/srcs/SetServer.cpp
@@ -17,6 +17,7 @@ int Server::serverSetup(std::string prt)
 	struct addrinfo *serverinfo;
 	int yes = 1;
 
+	serverName = "IRCserv";
 	const char *port = prt.c_str();
 	std::cout << "port " << port << std::endl;
 
@@ -92,13 +93,13 @@ int Server::poll_loop()
 			{
 				if(this->pfds[i].fd == this->pfds[0].fd)
 				{
-					if(acceptPendingConnections())
+					if(acceptPendingConnections() == -1)
 						return(-1);
 				}
 				else
 				{
 					if(recieve_msg(this->pfds[i].fd, i) == -1)
-							return(-1);
+						continue;
 				}
 			}
 			else if (this->pfds[i].revents & POLLOUT){
@@ -188,7 +189,7 @@ int Server::recieve_msg(int client_fd, int i)
 		setClientId(client_fd);
 		setMessage(buf);
 		std::cout << buf << std::endl;
-		if(parseMessage(client_fd))
+		if(parseMessage(client_fd) == -1)
 			return(-1);// we start parsing here
 		return (0);
 	}
@@ -203,16 +204,16 @@ int Server::parseMessage(int client_fd)
 	switch(get_command_type(msg.command))
 	{
 		case command::PASS:
-			if(cmd_pass(msg,client_fd))
+			if(cmd_pass(msg, *(_clients[client_fd])) == -1)
 				return(-1);
 			break ;
-		case command::NICK:
-			if(cmd_nick(msg,client_fd))
-				return(-1);
-			break ;
-		case command::USER:
-			if(cmd_user(msg,client_fd))
-				return(-1);
+		// case command::NICK:
+		// 	if(cmd_nick(msg,client_fd))
+		// 		return(-1);
+		// 	break ;
+		// case command::USER:
+		// 	if(cmd_user(msg,client_fd))
+		// 		return(-1);
 			break ;
 	}
 	return (0);
@@ -330,4 +331,9 @@ void Server::setMessage(const char* msg)
 			buf.clear();
 		}
 	}
+}
+
+const std::string &Server::getServerName() const
+{
+	return (this->serverName);
 }

--- a/srcs/commands/pass.cpp
+++ b/srcs/commands/pass.cpp
@@ -1,6 +1,7 @@
 
 #include "../../includes/Server.hpp"
 #include "../../includes/Commands.hpp"
+#include "../../includes/Reply.hpp"
 
 /**
  * @brief PASS command for setting 'connection password'
@@ -12,20 +13,27 @@
  * 
  * Example : /PASS secretpassword
  */
-int cmd_pass(std::string message, int client_fd);
+int cmd_pass(Message &msg, Client &Client)
 {
-	//if (password is empty){
-		//send ERR_NEEDMOREPARAMS
-	//}
-	//else if(client->_isRegistered == 3)
-	//{
-		//send ERR_ALREADYREGISTERED
-	//}
-	//else if(password is incorrect){
-		//send ERR_PASSWDMISMATCH
-	//}
-	//else{
-		//client->_isRegistered = 1;
-	//}
+	std::string servername = Client.getServerName();
+
+	if (msg.params.size() == 0)
+	{
+		send(Client.getClientFd(), ERR_NEEDMOREPARAMS(servername).c_str(), ERR_NEEDMOREPARAMS(servername).length(), 0);
+		return (-1);
+	}
+	else if(Client.getRegisteration() == 3)
+	{
+		send(Client.getClientFd(), ERR_ALREADYREGISTRED(servername).c_str(), ERR_ALREADYREGISTRED(servername).length(), 0);
+		return (-1);
+	}
+	// else if(password is incorrect){
+	// 	send ERR_PASSWDMISMATCH
+	// }
+	else
+	{
+		Client.setRegisteration(1);
+		return (0);
+	}
 
 }


### PR DESCRIPTION
Servername is added to each client.
When receive message function returns -1 to poll routine, it doesn't break, it continues (when it breaks, it goes out of the poll routine entirely)
Parsing index is fixed.
Command takes Msg and Client class as param.