### PR TITLE
FI-68 removed Z flag from client

### DIFF
--- a/srcs/Client.cpp
+++ b/srcs/Client.cpp
@@ -9,7 +9,7 @@ Client::Client(){};
  * @param new_fd socket fd
  * @param _mode mode for USER, CHANNEL
  */
-Client::Client(int new_fd): _clientFd(new_fd), _serverName("🐾TYCHUNEN SERVER🐾"), _nickname(""), _mode("+Ziw"), _operatorPassword("TYCHUNEN"),_isRegistered(0), _welcomeSent(0), _isOperator(false), _maxChannels(0)
+Client::Client(int new_fd): _clientFd(new_fd), _serverName("🐾TYCHUNEN SERVER🐾"), _nickname(""), _mode("+iw"), _operatorPassword("TYCHUNEN"),_isRegistered(0), _welcomeSent(0), _isOperator(false), _maxChannels(0)
 {
 	std::vector<std::string>	_channelsJoined;
 }

--- a/srcs/Client.cpp
+++ b/srcs/Client.cpp
@@ -9,7 +9,7 @@ Client::Client(){};
  * @param new_fd socket fd
  * @param _mode mode for USER, CHANNEL
  */
-Client::Client(int new_fd): _clientFd(new_fd), _serverName("🐾TYCHUNEN SERVER🐾"), _nickname(""), _mode("+iw"), _operatorPassword("TYCHUNEN"),_isRegistered(0), _welcomeSent(0), _isOperator(false), _maxChannels(0)
+Client::Client(int new_fd): _clientFd(new_fd), _serverName("🐾TYCHUNEN SERVER🐾"), _nickname(""), _mode("+i"), _operatorPassword("TYCHUNEN"),_isRegistered(0), _welcomeSent(0), _isOperator(false), _maxChannels(0)
 {
 	std::vector<std::string>	_channelsJoined;
 }


### PR DESCRIPTION
Tested so that client flags are static, they can not be removed or added with MODE command (only o flag with OPER command). There was no required implementation in subject for user modes.
There are no default user flags for client when they first register, so it's completely up to our decision. I left flag i: marks the user as invisible. This means that the user's presence or absence on the network is not announced to other users. and the flag w: user receives wallops (user is broadcasted the common messages on server).